### PR TITLE
Add Instantly API server example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# test
+# Instantly MCP Server
+
+This repo contains a simple FastAPI-based server that proxies requests to the [Instantly](https://developer.instantly.ai/api/v2) API.
+
+## Usage
+
+1. Install dependencies (if not already installed):
+   ```bash
+   pip install fastapi uvicorn
+   ```
+   The server uses only built-in modules for HTTP requests, so no external HTTP client is required.
+
+2. Edit `instantly_server.py` and replace `YOUR_API_KEY` with your Instantly API key.
+
+3. Run the server:
+   ```bash
+   python3 instantly_server.py
+   ```
+
+   The server will start on `http://0.0.0.0:8000`.
+
+4. Example endpoints:
+   - `GET /campaigns` – list campaigns from Instantly
+   - `POST /campaigns` – create a campaign (pass JSON body)
+
+This code serves as a starting point and may need adjustments based on the specific Instantly API endpoints you wish to access.

--- a/instantly_server.py
+++ b/instantly_server.py
@@ -1,0 +1,54 @@
+import json
+from typing import Any, Dict
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+import urllib.request
+import urllib.error
+
+app = FastAPI()
+
+API_BASE_URL = "https://api.instantly.ai/api/v2"
+API_KEY = "YOUR_API_KEY"  # Replace with your Instantly API key
+
+
+def call_instantly(endpoint: str, method: str = "GET", data: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    url = f"{API_BASE_URL}{endpoint}"
+    headers = {
+        "Authorization": f"Bearer {API_KEY}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+    req_data = None
+    if data is not None:
+        req_data = json.dumps(data).encode("utf-8")
+    req = urllib.request.Request(url, data=req_data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            resp_data = resp.read().decode("utf-8")
+            return json.loads(resp_data)
+    except urllib.error.HTTPError as e:
+        error_msg = e.read().decode("utf-8")
+        return {"error": e.code, "message": error_msg}
+    except urllib.error.URLError as e:
+        return {"error": "network", "message": str(e.reason)}
+
+
+@app.get("/campaigns")
+def list_campaigns():
+    result = call_instantly("/campaigns")
+    return JSONResponse(content=result)
+
+
+@app.post("/campaigns")
+def create_campaign(payload: Dict[str, Any]):
+    result = call_instantly("/campaigns", method="POST", data=payload)
+    return JSONResponse(content=result)
+
+
+@app.get("/")
+def read_root():
+    return {"status": "Instantly MCP server running"}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- add `instantly_server.py` implementing a FastAPI server that proxies to the Instantly API
- document how to run the server and endpoints in README

## Testing
- `python3 -m py_compile instantly_server.py`
- `python3 instantly_server.py > /tmp/server.log 2>&1 &`